### PR TITLE
Fixed errors reported by quartus for successful build

### DIFF
--- a/Source-7400/7400-tb.v
+++ b/Source-7400/7400-tb.v
@@ -33,7 +33,7 @@ begin
   BInputs = {BLOCKS{1'b1}};
   A = {BInputs, AInputs};
 #4
-  for (i = 0; i < BLOCKS; i++)
+  for (i = 0; i < BLOCKS; i=i+1)
     tbassert(Y[i] == 1'b0, "Test 1");
 #0
   // all zeroes -> 1, enough time for output to rise
@@ -41,7 +41,7 @@ begin
   BInputs = {BLOCKS{1'b0}};
   A = {BInputs, AInputs};
 #6
-  for (i = 0; i < BLOCKS; i++)
+  for (i = 0; i < BLOCKS; i=i+1)
     tbassert(Y[i] == 1'b1, "Test 2");
 #0
   // only a single bit causes -> 1

--- a/Source-7400/7400.v
+++ b/Source-7400/7400.v
@@ -14,7 +14,7 @@ integer i;
 always @(*)
 begin
   computed = {BLOCKS{1'b1}};
-  for (i = 0; i < WIDTH_IN; i++)
+  for (i = 0; i < WIDTH_IN; i=i+1)
     computed = computed & A[i];
   computed = ~computed;
 end

--- a/Source-7400/7402-tb.v
+++ b/Source-7400/7402-tb.v
@@ -33,7 +33,7 @@ begin
   BInputs = {BLOCKS{1'b1}};
   A = {BInputs, AInputs};
 #4
-  for (i = 0; i < BLOCKS; i++)
+  for (i = 0; i < BLOCKS; i=i+1)
     tbassert(Y[i] == 1'b0, "Test 1");
 #0
   // all zeroes -> 1, enough time for output to rise
@@ -41,7 +41,7 @@ begin
   BInputs = {BLOCKS{1'b0}};
   A = {BInputs, AInputs};
 #6
-  for (i = 0; i < BLOCKS; i++)
+  for (i = 0; i < BLOCKS; i=i+1)
     tbassert(Y[i] == 1'b1, "Test 2");
 #0
   // only a single bit causes -> 0

--- a/Source-7400/7402.v
+++ b/Source-7400/7402.v
@@ -14,7 +14,7 @@ integer i;
 always @(*)
 begin
   computed = {BLOCKS{1'b0}};
-  for (i = 0; i < WIDTH_IN; i++)
+  for (i = 0; i < WIDTH_IN; i=i+1)
     computed = computed | A[i];
   computed = ~computed;
 end

--- a/Source-7400/7404-tb.v
+++ b/Source-7400/7404-tb.v
@@ -26,10 +26,10 @@ begin
   $dumpvars;
 
   // all ones -> 0
-  for (i = 0; i < BLOCKS; i++)
+  for (i = 0; i < BLOCKS; i=i+1)
     A[i] = 1'b1;
 #5
-  for (i = 0; i < BLOCKS; i++)
+  for (i = 0; i < BLOCKS; i=i+1)
     tbassert(Y[i] == 1'b0, "Test 1");
 #0
   // single bit change to zero causes -> 1, others unchanged
@@ -50,10 +50,10 @@ begin
   tbassert(Y[6] == 1'b1, "Test 3");
 #0
   // all zeroes -> 1
-  for (i = 0; i < BLOCKS; i++)
+  for (i = 0; i < BLOCKS; i=i+1)
     A[i] = 1'b0;
 #5
-  for (i = 0; i < BLOCKS; i++)
+  for (i = 0; i < BLOCKS; i=i+1)
     tbassert(Y[i] == 1'b1, "Test 4");
 #0
   // single bit change to one causes -> 0, others unchanged

--- a/Source-7400/7407-tb.v
+++ b/Source-7400/7407-tb.v
@@ -26,10 +26,10 @@ begin
   $dumpvars;
 
   // all zeroes -> 0
-  for (i = 0; i < BLOCKS; i++)
+  for (i = 0; i < BLOCKS; i=i+1)
     A[i] = 1'b0;
 #5
-  for (i = 0; i < BLOCKS; i++)
+  for (i = 0; i < BLOCKS; i=i+1)
     tbassert(Y[i] == 1'b0, "Test 1");
 #0
   // single bit change to one causes -> 1, others unchanged
@@ -50,10 +50,10 @@ begin
   tbassert(Y[6] == 1'b1, "Test 3");
 #0
   // all ones -> 1
-  for (i = 0; i < BLOCKS; i++)
+  for (i = 0; i < BLOCKS; i=i+1)
     A[i] = 1'b1;
 #5
-  for (i = 0; i < BLOCKS; i++)
+  for (i = 0; i < BLOCKS; i=i+1)
     tbassert(Y[i] == 1'b1, "Test 4");
 #0
   // single bit change to zero causes -> 0, others unchanged

--- a/Source-7400/7408-tb.v
+++ b/Source-7400/7408-tb.v
@@ -33,7 +33,7 @@ begin
   BInputs = {BLOCKS{1'b0}};
   A = {BInputs, AInputs};
 #4
-  for (i = 0; i < BLOCKS; i++)
+  for (i = 0; i < BLOCKS; i=i+1)
     tbassert(Y[i] == 1'b0, "Test 1");
 #0
   // all ones -> 1, enough time for output to rise
@@ -41,7 +41,7 @@ begin
   BInputs = {BLOCKS{1'b1}};
   A = {BInputs, AInputs};
 #6
-  for (i = 0; i < BLOCKS; i++)
+  for (i = 0; i < BLOCKS; i=i+1)
     tbassert(Y[i] == 1'b1, "Test 2");
 #0
   // only a single bit causes -> 0

--- a/Source-7400/7408.v
+++ b/Source-7400/7408.v
@@ -14,7 +14,7 @@ integer i;
 always @(*)
 begin
   computed = {BLOCKS{1'b1}};
-  for (i = 0; i < WIDTH_IN; i++)
+  for (i = 0; i < WIDTH_IN; i=i+1)
     computed = computed & A[i];
 end
 //------------------------------------------------//

--- a/Source-7400/7410-tb.v
+++ b/Source-7400/7410-tb.v
@@ -35,7 +35,7 @@ begin
   CInputs = AInputs;
   A = {CInputs, BInputs, AInputs};
 #10
-  for (i = 0; i < BLOCKS; i++)
+  for (i = 0; i < BLOCKS; i=i+1)
     tbassert(Y[i] == 1'b0, "Test 1");
 #0
   // all zeroes -> 1
@@ -44,7 +44,7 @@ begin
   CInputs = AInputs;
   A = {CInputs, BInputs, AInputs};
 #10
-  for (i = 0; i < BLOCKS; i++)
+  for (i = 0; i < BLOCKS; i=i+1)
     tbassert(Y[i] == 1'b1, "Test 2");
 #0
   // only a single bit causes -> 1

--- a/Source-7400/7410.v
+++ b/Source-7400/7410.v
@@ -14,7 +14,7 @@ integer i;
 always @(*)
 begin
   computed = {BLOCKS{1'b1}};
-  for (i = 0; i < WIDTH_IN; i++)
+  for (i = 0; i < WIDTH_IN; i=i+1)
     computed = computed & A[i];
   computed = ~computed;
 end

--- a/Source-7400/7411-tb.v
+++ b/Source-7400/7411-tb.v
@@ -35,7 +35,7 @@ begin
   CInputs = AInputs;
   A = {CInputs, BInputs, AInputs};
 #10
-  for (i = 0; i < BLOCKS; i++)
+  for (i = 0; i < BLOCKS; i=i+1)
     tbassert(Y[i] == 1'b0, "Test 1");
 #0
   // all ones -> 1
@@ -44,7 +44,7 @@ begin
   CInputs = AInputs;
   A = {CInputs, BInputs, AInputs};
 #10
-  for (i = 0; i < BLOCKS; i++)
+  for (i = 0; i < BLOCKS; i=i+1)
     tbassert(Y[i] == 1'b1, "Test 2");
 #0
   // only a single bit causes -> 0

--- a/Source-7400/7411.v
+++ b/Source-7400/7411.v
@@ -14,7 +14,7 @@ integer i;
 always @(*)
 begin
   computed = {BLOCKS{1'b1}};
-  for (i = 0; i < WIDTH_IN; i++)
+  for (i = 0; i < WIDTH_IN; i=i+1)
     computed = computed & A[i];
 end
 //------------------------------------------------//

--- a/Source-7400/74138.v
+++ b/Source-7400/74138.v
@@ -16,7 +16,7 @@ integer i;
 
 always @(*)
 begin
-  for (i = 0; i < WIDTH_OUT; i++)
+  for (i = 0; i < WIDTH_OUT; i=i+1)
   begin
     if (!Enable1_bar && !Enable2_bar && Enable3 && i == A)
       computed[i] = 1'b0;

--- a/Source-7400/74139.v
+++ b/Source-7400/74139.v
@@ -17,7 +17,7 @@ integer j;
 
 always @(*)
 begin
-  for (i = 0; i < BLOCKS; i++)
+  for (i = 0; i < BLOCKS; i=i+1)
   begin
     for (j = 0; j < WIDTH_OUT; j++)
     begin

--- a/Source-7400/74153.v
+++ b/Source-7400/74153.v
@@ -16,7 +16,7 @@ integer i;
 
 always @(*)
 begin
-  for (i = 0; i < BLOCKS; i++)
+  for (i = 0; i < BLOCKS; i=i+1)
   begin
     if (!Enable_bar[i])
       computed[i] = A[i][Select];

--- a/Source-7400/74154.v
+++ b/Source-7400/74154.v
@@ -15,7 +15,7 @@ integer i;
 
 always @(*)
 begin
-  for (i = 0; i < WIDTH_OUT; i++)
+  for (i = 0; i < WIDTH_OUT; i=i+1)
   begin
     if (!Enable1_bar && !Enable2_bar && i == A)
       computed[i] = 1'b0;

--- a/Source-7400/74155.v
+++ b/Source-7400/74155.v
@@ -18,7 +18,7 @@ integer i;
 
 always @(*)
 begin
-  for (i = 0; i < WIDTH_OUT; i++)
+  for (i = 0; i < WIDTH_OUT; i=i+1)
   begin
     if (Enable1C && !Enable1G_bar && i == A)
       computed[BLOCK0][i] = 1'b0;

--- a/Source-7400/74160-tb.v
+++ b/Source-7400/74160-tb.v
@@ -107,7 +107,7 @@ begin
 
   D_next = 4'b1001;  // initial value to start the loop
 
-  for (i = 1; i <= 6; i++)
+  for (i = 1; i <= 6; i=i+1)
   begin
     Q_expected = D_next;
     D_next = (Q_expected + 1) ^ 5;  // use a random value for next input
@@ -521,7 +521,7 @@ begin
   // repeat tests: load values above BCD 9 -> outputs go back on track to within the
   // BCD decade count range at the next clock edge
 
-  for (i = 10; i <= 15; i++)
+  for (i = 10; i <= 15; i=i+1)
   begin
     parallel_load_and_tick(i);
 #20
@@ -542,7 +542,7 @@ begin
   ENT = 1'b1;
   ENP = 1'b0;
 
-  for (i = 10; i <= 15; i++)
+  for (i = 10; i <= 15; i=i+1)
   begin
     parallel_load_and_tick(i);
 #20

--- a/Source-7400/74161-tb.v
+++ b/Source-7400/74161-tb.v
@@ -98,7 +98,7 @@ begin
 
   D_next = 3'b111;  // initial value to start the loop
 
-  for (i = 1; i <= 6; i++)
+  for (i = 1; i <= 6; i=i+1)
   begin
     Q_expected = D_next;
     D_next = (Q_expected + 2) ^ 5;  // use a random value for next input

--- a/Source-7400/74162-tb.v
+++ b/Source-7400/74162-tb.v
@@ -107,7 +107,7 @@ begin
 
   D_next = 4'b1001;  // initial value to start the loop
 
-  for (i = 1; i <= 6; i++)
+  for (i = 1; i <= 6; i=i+1)
   begin
     Q_expected = D_next;
     D_next = (Q_expected + 1) ^ 5;  // use a random value for next input
@@ -479,7 +479,7 @@ begin
   // repeat tests: load values above BCD 9 -> outputs go back on track to within the
   // BCD decade count range at the next clock edge
 
-  for (i = 10; i <= 15; i++)
+  for (i = 10; i <= 15; i=i+1)
   begin
     parallel_load_and_tick(i);
 #20
@@ -500,7 +500,7 @@ begin
   ENT = 1'b1;
   ENP = 1'b0;
 
-  for (i = 10; i <= 15; i++)
+  for (i = 10; i <= 15; i=i+1)
   begin
     parallel_load_and_tick(i);
 #20

--- a/Source-7400/74163-tb.v
+++ b/Source-7400/74163-tb.v
@@ -98,7 +98,7 @@ begin
 
   D_next = 3'b111;  // initial value to start the loop
 
-  for (i = 1; i <= 6; i++)
+  for (i = 1; i <= 6; i=i+1)
   begin
     Q_expected = D_next;
     D_next = (Q_expected + 2) ^ 5;  // use a random value for next input

--- a/Source-7400/7420.v
+++ b/Source-7400/7420.v
@@ -14,7 +14,7 @@ integer i;
 always @(*)
 begin
   computed = {BLOCKS{1'b1}};
-  for (i = 0; i < WIDTH_IN; i++)
+  for (i = 0; i < WIDTH_IN; i=i+1)
     computed = computed & A[i];
   computed = ~computed;
 end

--- a/Source-7400/7421.v
+++ b/Source-7400/7421.v
@@ -14,7 +14,7 @@ integer i;
 always @(*)
 begin
   computed = {BLOCKS{1'b1}};
-  for (i = 0; i < WIDTH_IN; i++)
+  for (i = 0; i < WIDTH_IN; i=i+1)
     computed = computed & A[i];
 end
 //------------------------------------------------//

--- a/Source-7400/74238.v
+++ b/Source-7400/74238.v
@@ -16,7 +16,7 @@ integer i;
 
 always @(*)
 begin
-  for (i = 0; i < WIDTH_OUT; i++)
+  for (i = 0; i < WIDTH_OUT; i=i+1)
   begin
     if (!Enable1_bar && !Enable2_bar && Enable3 && i == A)
       computed[i] = 1'b1;

--- a/Source-7400/74260.v
+++ b/Source-7400/74260.v
@@ -14,7 +14,7 @@ integer i;
 always @(*)
 begin
   computed = {BLOCKS{1'b0}};
-  for (i = 0; i < WIDTH_IN; i++)
+  for (i = 0; i < WIDTH_IN; i=i+1)
     computed = computed | A[i];
   computed = ~computed;
 end

--- a/Source-7400/74266.v
+++ b/Source-7400/74266.v
@@ -18,7 +18,7 @@ begin
   // - follows the precedent of 3-input XOR gate 741G386
   // - conforms to chaining of XNOR to create arbitrary wider input, e.g. "(A XNOR B) XNOR C"
   computed = {BLOCKS{1'b0}};
-  for (i = 0; i < WIDTH_IN; i++)
+  for (i = 0; i < WIDTH_IN; i=i+1)
     computed = computed ^ A[i];
   computed = ~computed;
 end

--- a/Source-7400/7427-tb.v
+++ b/Source-7400/7427-tb.v
@@ -35,7 +35,7 @@ begin
   CInputs = AInputs;
   A = {CInputs, BInputs, AInputs};
 #10
-  for (i = 0; i < BLOCKS; i++)
+  for (i = 0; i < BLOCKS; i=i+1)
     tbassert(Y[i] == 1'b0, "Test 1");
 #0
   // all zeroes -> 1
@@ -44,7 +44,7 @@ begin
   CInputs = AInputs;
   A = {CInputs, BInputs, AInputs};
 #10
-  for (i = 0; i < BLOCKS; i++)
+  for (i = 0; i < BLOCKS; i=i+1)
     tbassert(Y[i] == 1'b1, "Test 2");
 #0
   // only a single bit causes -> 0

--- a/Source-7400/7427.v
+++ b/Source-7400/7427.v
@@ -14,7 +14,7 @@ integer i;
 always @(*)
 begin
   computed = {BLOCKS{1'b0}};
-  for (i = 0; i < WIDTH_IN; i++)
+  for (i = 0; i < WIDTH_IN; i=i+1)
     computed = computed | A[i];
   computed = ~computed;
 end

--- a/Source-7400/74273-tb.v
+++ b/Source-7400/74273-tb.v
@@ -185,7 +185,7 @@ begin
 
   D_next = 3'b000;  // initial value to start the loop
 
-  for (i = 1; i <= 3; i++)
+  for (i = 1; i <= 3; i=i+1)
   begin
     Q_expected = D_next;
 

--- a/Source-7400/74283-tb.v
+++ b/Source-7400/74283-tb.v
@@ -52,7 +52,7 @@ begin
 
   // repeat tests: "C_in" is clear then set
 
-  for (i = 1; i <= 2; i++)
+  for (i = 1; i <= 2; i=i+1)
   begin
     case (i)
       1:

--- a/Source-7400/7430.v
+++ b/Source-7400/7430.v
@@ -13,7 +13,7 @@ integer i;
 always @(*)
 begin
   computed = 1'b1;
-  for (i = 0; i < WIDTH_IN; i++)
+  for (i = 0; i < WIDTH_IN; i=i+1)
     computed = computed & A[i];
   computed = ~computed;
 end

--- a/Source-7400/7432-tb.v
+++ b/Source-7400/7432-tb.v
@@ -33,7 +33,7 @@ begin
   BInputs = AInputs;
   A = {BInputs, AInputs};
 #6
-  for (i = 0; i < BLOCKS; i++)
+  for (i = 0; i < BLOCKS; i=i+1)
     tbassert(Y[i] == 1'b1, "Test 1");
 #0
   // all zeroes -> 0
@@ -41,7 +41,7 @@ begin
   BInputs = AInputs;
   A = {BInputs, AInputs};
 #6
-  for (i = 0; i < BLOCKS; i++)
+  for (i = 0; i < BLOCKS; i=i+1)
     tbassert(Y[i] == 1'b0, "Test 2");
 #0
   // only a single bit causes -> 1

--- a/Source-7400/7432.v
+++ b/Source-7400/7432.v
@@ -14,7 +14,7 @@ integer i;
 always @(*)
 begin
   computed = {BLOCKS{1'b0}};
-  for (i = 0; i < WIDTH_IN; i++)
+  for (i = 0; i < WIDTH_IN; i=i+1)
     computed = computed | A[i];
 end
 //------------------------------------------------//

--- a/Source-7400/74352.v
+++ b/Source-7400/74352.v
@@ -16,7 +16,7 @@ integer i;
 
 always @(*)
 begin
-  for (i = 0; i < BLOCKS; i++)
+  for (i = 0; i < BLOCKS; i=i+1)
   begin
     if (!Enable_bar[i])
       computed[i] = A[i][Select];

--- a/Source-7400/7442.v
+++ b/Source-7400/7442.v
@@ -13,7 +13,7 @@ integer i;
 
 always @(*)
 begin
-  for (i = 0; i < WIDTH_OUT; i++)
+  for (i = 0; i < WIDTH_OUT; i=i+1)
   begin
     if (i == A)
       computed[i] = 1'b0;

--- a/Source-7400/7485-tb.v
+++ b/Source-7400/7485-tb.v
@@ -40,7 +40,7 @@ begin
 
   // repeat tests: three different valid cascading inputs
 
-  for (i = 1; i <= 3; i++)
+  for (i = 1; i <= 3; i=i+1)
   begin
     case (i)
       1:

--- a/Source-7400/7486.v
+++ b/Source-7400/7486.v
@@ -17,7 +17,7 @@ begin
   // - follows the precedent of 3-input XOR gate 741G386
   // - conforms to chaining of XOR to create arbitrary wider input, e.g. "(A XOR B) XOR C"
   computed = {BLOCKS{1'b0}};
-  for (i = 0; i < WIDTH_IN; i++)
+  for (i = 0; i < WIDTH_IN; i=i+1)
     computed = computed ^ A[i];
 end
 //------------------------------------------------//

--- a/Source-7400/tbhelper.v
+++ b/Source-7400/tbhelper.v
@@ -1,9 +1,9 @@
 `timescale 1ns/1ps
 `default_nettype none
 
-`define ASSIGN_UNPACK(PK_WIDTH, PK_LEN, UNPK_DEST, PK_SRC) wire [PK_WIDTH*PK_LEN-1:0] PK_IN_BUS; assign PK_IN_BUS=PK_SRC; genvar unpk_idx; generate for (unpk_idx=0; unpk_idx<PK_LEN; unpk_idx=unpk_idx+1) begin assign UNPK_DEST[unpk_idx][PK_WIDTH-1:0]=PK_IN_BUS[PK_WIDTH*unpk_idx+:PK_WIDTH]; end endgenerate
+`define ASSIGN_UNPACK(PK_WIDTH, PK_LEN, UNPK_DEST, PK_SRC) wire [PK_WIDTH*PK_LEN-1:0] PK_IN_BUS; assign PK_IN_BUS=PK_SRC; genvar unpk_idx; generate for (unpk_idx=0; unpk_idx<PK_LEN; unpk_idx=unpk_idx+1) begin : generate_assign_unpack assign UNPK_DEST[unpk_idx][PK_WIDTH-1:0]=PK_IN_BUS[PK_WIDTH*unpk_idx+:PK_WIDTH]; end endgenerate
 
-`define ASSIGN_PACK(PK_WIDTH, PK_LEN, UNPK_SRC, PK_DEST) wire [PK_WIDTH*PK_LEN-1:0] PK_OUT_BUS; assign PK_DEST=PK_OUT_BUS; genvar pk_idx; generate for (pk_idx=0; pk_idx<PK_LEN; pk_idx=pk_idx+1) begin assign PK_OUT_BUS[PK_WIDTH*pk_idx+:PK_WIDTH]=UNPK_SRC[pk_idx][PK_WIDTH-1:0]; end endgenerate
+`define ASSIGN_PACK(PK_WIDTH, PK_LEN, UNPK_SRC, PK_DEST) wire [PK_WIDTH*PK_LEN-1:0] PK_OUT_BUS; assign PK_DEST=PK_OUT_BUS; genvar pk_idx; generate for (pk_idx=0; pk_idx<PK_LEN; pk_idx=pk_idx+1) begin : generate_assign_pack assign PK_OUT_BUS[PK_WIDTH*pk_idx+:PK_WIDTH]=UNPK_SRC[pk_idx][PK_WIDTH-1:0]; end endgenerate
 
 `define TBASSERT_METHOD(TB_NAME) reg [512:0] tbassertLastPassed = ""; task TB_NAME(input condition, input [512:0] s); if (condition === 1'bx) $display("-Failed === x value: %-s", s); else if (condition == 0) $display("-Failed: %-s", s); else if (s != tbassertLastPassed) begin $display("Passed: %-s", s); tbassertLastPassed = s; end endtask
 


### PR DESCRIPTION
I wanted to use these logic gates within Quartus 18.1 Lite IDE, but found that Quartus had numerous build issues. I modified the for loops to use i=i+1 rather than post-increment (is this valid syntax?) & added genblock labels (which are optional) but were reported as errors in Quartus. Files build fine now.