### PR TITLE
Add 74125,74126,74244 buffers

### DIFF
--- a/device-index.md
+++ b/device-index.md
@@ -1,6 +1,9 @@
 ## Buffers, Inverters
 [7404](source-7400/7404.v) Hex inverter<br />
 [7407](source-7400/7407.v) Hex buffer/driver (OC)<br />
+[74125](source-7400/74125.v) Quad bus buffer, negative enable<br />
+[74126](source-7400/74126.v) Quad bus buffer, positive enable<br />
+[74244](source-7400/74244.v) Octal buffer with 3-state output<br />
 
 ## Gates
 [7400](source-7400/7400.v) Quad 2-input NAND gate<br />

--- a/source-7400/74125.v
+++ b/source-7400/74125.v
@@ -1,0 +1,23 @@
+// Quad bus buffer, negative enable
+
+module ttl_74125 #(parameter BLOCKS = 4, DELAY_RISE = 0, DELAY_FALL = 0)
+(
+  input [BLOCKS-1:0] C,
+  input [BLOCKS-1:0] A,
+  output [BLOCKS-1:0] Y
+);
+
+//------------------------------------------------//
+integer i;
+reg [BLOCKS-1:0] computed;
+
+always @(*)
+begin
+  for (i = 0; i < BLOCKS; i++)
+    computed[i] = C[i] ? 1'bZ : A[i];
+end
+//------------------------------------------------//
+
+assign #(DELAY_RISE, DELAY_FALL) Y = computed;
+
+endmodule

--- a/source-7400/74126.v
+++ b/source-7400/74126.v
@@ -1,0 +1,23 @@
+// Quad bus buffer, positive enable
+
+module ttl_74126 #(parameter BLOCKS = 4, DELAY_RISE = 0, DELAY_FALL = 0)
+(
+  input [BLOCKS-1:0] C,
+  input [BLOCKS-1:0] A,
+  output [BLOCKS-1:0] Y
+);
+
+//------------------------------------------------//
+integer i;
+reg [BLOCKS-1:0] computed;
+
+always @(*)
+begin
+  for (i = 0; i < BLOCKS; i++)
+    computed[i] = C[i] ? A[i] : 1'bZ;
+end
+//------------------------------------------------//
+
+assign #(DELAY_RISE, DELAY_FALL) Y = computed;
+
+endmodule

--- a/source-7400/74244.v
+++ b/source-7400/74244.v
@@ -1,0 +1,23 @@
+// Octal buffer with 3-state output
+
+module ttl_74244 #(parameter WIDTH = 8, DELAY_RISE = 0, DELAY_FALL = 0)
+(
+  input [(WIDTH-1)/4:0] G_bar,
+  input [WIDTH-1:0] A,
+  output [WIDTH-1:0] Y
+);
+
+//------------------------------------------------//
+integer i;
+reg [WIDTH-1:0] computed;
+
+always @(*)
+begin
+  for (i = 0; i < WIDTH; i++)
+    computed[i] = G_bar[i/4] ? 1'bZ : A[i];
+end
+//------------------------------------------------//
+
+assign #(DELAY_RISE, DELAY_FALL) Y = computed;
+
+endmodule


### PR DESCRIPTION
I believe these work, but I haven't written test benches yet. Mainly posting them here so that they're there, and perhaps as a starting point towards merging it.

I expect you'd want test benches before you merge it, but I have almost no experience with Verilog and don't know that I'm well-suited to do it. Perhaps you could point me in the right direction?

Also I think the 74244 would probably want to use 2 BLOCKS of WIDTH 4, instead of WIDTH = 8.

Thanks for making this repo, it is very helpful. I'm using it to help design a CPU: https://github.com/jes/ttl-cpu - I do have a test bench system in that repo but it is very ad-hoc and bad. It is quite possible that I'll be creating more 74xx chips.